### PR TITLE
miller: add caveat message

### DIFF
--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -29,6 +29,13 @@ class Miller < Formula
     system "make", "install"
   end
 
+
+  def caveats
+    <<~EOS
+      🃏 Some people call me Maurice 🃏
+    EOS
+  end
+
   test do
     (testpath/"test.csv").write <<~EOS
       a,b,c

--- a/Formula/miller.rb
+++ b/Formula/miller.rb
@@ -29,7 +29,6 @@ class Miller < Formula
     system "make", "install"
   end
 
-
   def caveats
     <<~EOS
       🃏 Some people call me Maurice 🃏


### PR DESCRIPTION
In response to johnkerl/miller#343 (approved by @johnkerl), add a humorous message that's shown to the user when they install Miller.  (Or when they request info about the formula.)

Resolves johnkerl/miller#343.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
